### PR TITLE
Add Cloudflare Pages deployment support

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: cloudflare-pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libcurl development headers
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build Jekyll site
+        run: |
+          bundle exec jekyll clean
+          bundle exec jekyll build --future --drafts --unpublished
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ldk-review-club
+          directory: _site

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ the site locally. Ruby 3.0 is recommended. Once they are set up:
 In case of any issues, don't hesitate to run the following to update rubygems,
 bundler, and dependencies: `gem update --system && gem update && bundle update`
 
+## Cloudflare Pages Deployment
+
+This site can be deployed to [Cloudflare Pages](https://pages.cloudflare.com/)
+via GitHub Actions. The workflow in
+`.github/workflows/deploy-cloudflare-pages.yml` builds the Jekyll site and
+uploads it to Cloudflare Pages on every push to `main`.
+
+### Prerequisites
+
+1. Create a Cloudflare Pages project named `ldk-review-club` (or update the
+   `projectName` field in the workflow to match your project name).
+2. Create a Cloudflare API token with the **Cloudflare Pages — Edit** permission.
+3. Add the following repository secrets
+   (Settings → Secrets and variables → Actions):
+   - `CLOUDFLARE_API_TOKEN` — your Cloudflare API token
+   - `CLOUDFLARE_ACCOUNT_ID` — your Cloudflare account ID
+
+Once configured, every push to `main` triggers a deployment. You can also
+trigger a deployment manually from the Actions tab (`workflow_dispatch`).
+
 ## Making a new post
 
 See the [hosting.md](hosting.md) doc for how to create a post for an upcoming meeting.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/deploy-cloudflare-pages.yml` — GitHub Actions workflow that builds the Jekyll site and deploys to Cloudflare Pages on every push to `main`
- Build step mirrors the Makefile `build` target (`jekyll build --future --drafts --unpublished`)
- Includes concurrency control to cancel superseded deployments, `libcurl4-openssl-dev` for the `curb` gem, and bundler caching
- Document required `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repository secrets in README

## Prerequisites (before enabling)

1. Create a Cloudflare Pages project named `ldk-review-club`
2. Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as repository secrets

## Test plan

- [ ] Workflow YAML passes `js-yaml` validation (done locally)
- [ ] Build command matches existing `Makefile` `build` target exactly
- [ ] Configure secrets and trigger a deployment via `workflow_dispatch` to verify end-to-end