### PR TITLE
fix: publish future review club meetings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ markdown:            kramdown
 highlighter:         rouge
 permalink:           none
 plugins:             [jekyll-paginate, jekyll-sitemap, jekyll-feed, jekyll-seo-tag]
+future:              true
 
 sass:
   sass_dir: assets/css

--- a/test/test_jekyll_config.rb
+++ b/test/test_jekyll_config.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+require 'yaml'
+
+class TestJekyllConfig < Minitest::Test
+  def test_future_meetings_are_published
+    config_path = File.expand_path('../_config.yml', __dir__)
+    config = YAML.safe_load(File.read(config_path), permitted_classes: [Symbol])
+
+    assert_equal true, config['future']
+  end
+end


### PR DESCRIPTION
What was broken:
Netlify ran Jekyll without --future, so the July 17 #4463 meeting was omitted from the July 14 production build.

Root cause:
Local Makefile builds include --future, but that behavior was not encoded in the shared Jekyll configuration used by the Netlify app command.

What changed:
- Enable future posts in _config.yml.
- Add a regression test for the setting.

Verification:
- Focused config test passes.
- A normal jekyll build generates _site/4463.html and lists #4463 under Upcoming Meetings.